### PR TITLE
Bump p-kubernetes dependency

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/joeduffy/pulumi-go-helmbase v0.0.11
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.7.3
+	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.8.2
 	github.com/pulumi/pulumi/pkg/v3 v3.12.0
 	github.com/pulumi/pulumi/sdk/v3 v3.13.2
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -516,6 +516,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.7.3 h1:b4v1fcewsnuGB0ww0VtmgDiAz4W26K80qrhERG19zNQ=
 github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.7.3/go.mod h1:A+uAbOT/1EavvoJOMxjmnXlHQOhEbRCU57xiPuPXl8I=
+github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.8.2 h1:exH5XsJ5GUCPeyoCZqisUGuWbfIUyHZwpR7mghHqvjU=
+github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.8.2/go.mod h1:8iErNQxdXG7/Nze+2cyG1UEZLHqeyK8q3DwMgpyfZyg=
 github.com/pulumi/pulumi/pkg/v3 v3.12.0 h1:pkfMQpCK2kQhRzqijiLtM/Y/wJOqSO2JQQJZhKGZoQE=
 github.com/pulumi/pulumi/pkg/v3 v3.12.0/go.mod h1:OKKvB7W0q739IaDSlai/bpNBTc7+5/sTUwysYjZ1we8=
 github.com/pulumi/pulumi/sdk/v3 v3.3.1/go.mod h1:GBHyQ7awNQSRmiKp/p8kIKrGrMOZeA/k2czoM/GOqds=


### PR DESCRIPTION
Fixes #1 

This was fixed in https://github.com/pulumi/pulumi-kubernetes/releases/tag/v3.8.1

Probably need a dependabot chore to update dependencies?