### PR TITLE
fix: include scripts dir into node package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ build_nodejs_sdk:: gen_nodejs_sdk
 		yarn install && \
 		yarn run tsc --version && \
 		yarn run tsc && \
+		cp -R scripts/ bin && \
 		cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json && \
 		rm ./bin/package.json.bak


### PR DESCRIPTION
This is a copy of the fix that was applied to the [pulumi-kubernetes-ingress-nginx](https://github.com/pulumi/pulumi-kubernetes-ingress-nginx) repo here:

* https://github.com/pulumi/pulumi-kubernetes-ingress-nginx/commit/7eb3db596a4eded4698d6ada05a921caec2280cc

I am guessing there might be other repos which will have exactly the same issue. Possibly worth checking (I will have a look if I have time).

@lblackstone FYI. Thanks!