### PR TITLE
Fix SDK builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ install_dotnet_sdk:: # Required by CI
 	find . -name '*.nupkg' -print -exec cp -p {} ${WORKING_DIR}/nuget \;
 
 generate_dotnet: gen_dotnet_sdk # Required by CI
-build_dotnet: # Required by CI
+build_dotnet: build_dotnet_sdk # Required by CI
 
 # Node.js SDK
 
@@ -113,8 +113,8 @@ build_python_sdk:: gen_python_sdk
 		rm ./bin/setup.py.bak && \
 		cd ./bin && python3 setup.py build sdist
 
-generate_python: build_python_sdk # Required by CI
-build_python: # Required by CI
+generate_python: gen_python_sdk # Required by CI
+build_python: build_python_sdk # Required by CI
 install_python_sdk:: # Required by CI
 
 # Java SDK
@@ -123,4 +123,6 @@ generate_java: # Required by CI
 	pulumi package gen-sdk ${SCHEMA_PATH} -o sdk --language java
 	cp ${WORKING_DIR}/README.md sdk/java
 build_java: # Required by CI
+	cd sdk/java && gradle --console=plain build
+
 install_java_sdk: # Required by CI

--- a/provider/cmd/pulumi-resource-kubernetes-cert-manager/schema.json
+++ b/provider/cmd/pulumi-resource-kubernetes-cert-manager/schema.json
@@ -901,7 +901,8 @@
           "dependencies": {
             "com.google.code.findbugs:jsr305": "3.0.2",
             "com.google.code.gson:gson": "2.8.9",
-            "com.pulumi:pulumi": "0.9.9"
+            "com.pulumi:pulumi": "0.9.9",
+            "com.pulumi:kubernetes": "4.11.0"
           },
           "gradleNexusPublishPluginVersion": "1.1.0",
           "gradleTest": ""

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -44,6 +44,7 @@ repositories {
 dependencies {
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("com.google.code.gson:gson:2.8.9")
+    implementation("com.pulumi:kubernetes:4.11.0")
     implementation("com.pulumi:pulumi:0.9.9")
 }
 


### PR DESCRIPTION
The pre-release job [failed](https://github.com/pulumi/pulumi-kubernetes-cert-manager/actions/runs/8745169052) because I had some of our SDK targets mixed up.

We were also missing a dependency on Kubernetes for Java.