### PR TITLE
Adds support for repository to be an output, Adding in test for #133

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps maintain consistent coding styles across editors and IDEs
+# More details at https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{ts,tsx}]
+indent_style = space
+indent_size = 2

--- a/examples/examples_ts_test.go
+++ b/examples/examples_ts_test.go
@@ -46,6 +46,6 @@ func TestTsCertManagerPreview(t *testing.T) {
 			opttest.LocalProviderPath("pulumi-kubernetes-cert-manager", filepath.Join(getCwd(t), "..", "bin")),
 			opttest.YarnLink("@pulumi/kubernetes-cert-manager"),
 		)
-		p.Preview(t, optpreview.ExpectNoChanges())
+		p.Preview(t)
 	})
 }

--- a/examples/examples_ts_test.go
+++ b/examples/examples_ts_test.go
@@ -31,9 +31,21 @@ func TestTsExamples(t *testing.T) {
 					p.SetConfig(t, key, value)
 				}
 			}
+			p.SetConfig(t, "repository", "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-controller")
 			p.Up(t)
 			p.Preview(t, optpreview.ExpectNoChanges())
 			p.Refresh(t, optrefresh.ExpectNoChanges())
 		})
 	}
+}
+
+// This tests the Output being passed to repository to fix #133
+func TestTsCertManagerPreview(t *testing.T) {
+	t.Run("TestSimpleCertManagerTsPreview", func(t *testing.T) {
+		p := pulumitest.NewPulumiTest(t, "simple-cert-manager-ts",
+			opttest.LocalProviderPath("pulumi-kubernetes-cert-manager", filepath.Join(getCwd(t), "..", "bin")),
+			opttest.YarnLink("@pulumi/kubernetes-cert-manager"),
+		)
+		p.Preview(t, optpreview.ExpectNoChanges())
+	})
 }

--- a/examples/simple-cert-manager-ts/index.ts
+++ b/examples/simple-cert-manager-ts/index.ts
@@ -6,10 +6,33 @@ const ns = new k8s.core.v1.Namespace("sandbox-ns");
 
 // Install a cert manager into our cluster.
 const manager = new certmanager.CertManager("cert-manager", {
-  installCRDs: true,
-  helmOptions: {
-    namespace: ns.metadata.name,
-  },
+    installCRDs: true,
+    helmOptions: {
+        namespace: ns.metadata.name,
+        version: "v1.15.3",
+    },
+    image: {
+        repository: "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-controller",
+        tag: "v1.15.3-eks-a-v0.21.3-dev-build.0"
+    },
+    cainjector: {
+        "image": {
+            repository: "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-cainjector",
+            tag: "v1.15.3-eks-a-v0.21.3-dev-build.0",
+        },
+    },
+    startupapicheck: {
+        "image": {
+            repository: "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-startupapicheck",
+            tag: "v1.15.3-eks-a-v0.21.3-dev-build.0",
+        }
+    },
+    webhook: {
+        image: {
+            repository: "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-webhook",
+            tag: "v1.15.3-eks-a-v0.21.3-dev-build.0"
+        }
+    }
 });
 
 // Create a cluster issuer that uses self-signed certificates.
@@ -18,19 +41,19 @@ const manager = new certmanager.CertManager("cert-manager", {
 // https://cert-manager.io/docs/configuration/selfsigned/
 // for additional details on other signing providers.
 const issuer = new k8s.apiextensions.CustomResource(
-  "issuer",
-  {
-    apiVersion: "cert-manager.io/v1",
-    kind: "Issuer",
-    metadata: {
-      name: "selfsigned-issuer",
-      namespace: ns.metadata.name,
+    "issuer",
+    {
+        apiVersion: "cert-manager.io/v1",
+        kind: "Issuer",
+        metadata: {
+            name: "selfsigned-issuer",
+            namespace: ns.metadata.name,
+        },
+        spec: {
+            selfSigned: {},
+        },
     },
-    spec: {
-      selfSigned: {},
-    },
-  },
-  { dependsOn: manager }
+    { dependsOn: manager }
 );
 
 export const certManagerStatus = manager.status;

--- a/examples/simple-cert-manager-ts/index.ts
+++ b/examples/simple-cert-manager-ts/index.ts
@@ -1,38 +1,45 @@
 import * as k8s from "@pulumi/kubernetes";
 import * as certmanager from "@pulumi/kubernetes-cert-manager";
+import * as random from "@pulumi/random";
+
+const randomString = new random.RandomString("random", {
+  length: 16,
+  special: true,
+  overrideSpecial: "/@£$",
+})
 
 // Create a sandbox namespace.
 const ns = new k8s.core.v1.Namespace("sandbox-ns");
 
 // Install a cert manager into our cluster.
 const manager = new certmanager.CertManager("cert-manager", {
-    installCRDs: true,
-    helmOptions: {
-        namespace: ns.metadata.name,
-        version: "v1.15.3",
+  installCRDs: true,
+  helmOptions: {
+    namespace: ns.metadata.name,
+    version: "v1.15.3",
+  },
+  image: {
+    repository: randomString.result.apply(result => "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-controller"),
+    tag: "v1.15.3-eks-a-v0.21.3-dev-build.0"
+  },
+  cainjector: {
+    "image": {
+      repository: "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-cainjector",
+      tag: "v1.15.3-eks-a-v0.21.3-dev-build.0",
     },
-    image: {
-        repository: "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-controller",
-        tag: "v1.15.3-eks-a-v0.21.3-dev-build.0"
-    },
-    cainjector: {
-        "image": {
-            repository: "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-cainjector",
-            tag: "v1.15.3-eks-a-v0.21.3-dev-build.0",
-        },
-    },
-    startupapicheck: {
-        "image": {
-            repository: "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-startupapicheck",
-            tag: "v1.15.3-eks-a-v0.21.3-dev-build.0",
-        }
-    },
-    webhook: {
-        image: {
-            repository: "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-webhook",
-            tag: "v1.15.3-eks-a-v0.21.3-dev-build.0"
-        }
+  },
+  startupapicheck: {
+    "image": {
+      repository: "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-startupapicheck",
+      tag: "v1.15.3-eks-a-v0.21.3-dev-build.0",
     }
+  },
+  webhook: {
+    image: {
+      repository: "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-webhook",
+      tag: "v1.15.3-eks-a-v0.21.3-dev-build.0"
+    }
+  }
 });
 
 // Create a cluster issuer that uses self-signed certificates.
@@ -41,19 +48,19 @@ const manager = new certmanager.CertManager("cert-manager", {
 // https://cert-manager.io/docs/configuration/selfsigned/
 // for additional details on other signing providers.
 const issuer = new k8s.apiextensions.CustomResource(
-    "issuer",
-    {
-        apiVersion: "cert-manager.io/v1",
-        kind: "Issuer",
-        metadata: {
-            name: "selfsigned-issuer",
-            namespace: ns.metadata.name,
-        },
-        spec: {
-            selfSigned: {},
-        },
+  "issuer",
+  {
+    apiVersion: "cert-manager.io/v1",
+    kind: "Issuer",
+    metadata: {
+      name: "selfsigned-issuer",
+      namespace: ns.metadata.name,
     },
-    { dependsOn: manager }
+    spec: {
+      selfSigned: {},
+    },
+  },
+  { dependsOn: manager }
 );
 
 export const certManagerStatus = manager.status;

--- a/examples/simple-cert-manager-ts/index.ts
+++ b/examples/simple-cert-manager-ts/index.ts
@@ -1,12 +1,19 @@
 import * as k8s from "@pulumi/kubernetes";
 import * as certmanager from "@pulumi/kubernetes-cert-manager";
 import * as random from "@pulumi/random";
+import * as pulumi from "@pulumi/pulumi"
 
 const randomString = new random.RandomString("random", {
   length: 16,
-  special: true,
-  overrideSpecial: "/@£$",
+  special: false,
 })
+
+const conf = new pulumi.Config()
+const confRepo = conf.get("repository")
+let repository = randomString.result
+if (confRepo) {
+  repository = pulumi.output(confRepo)
+}
 
 // Create a sandbox namespace.
 const ns = new k8s.core.v1.Namespace("sandbox-ns");
@@ -19,7 +26,7 @@ const manager = new certmanager.CertManager("cert-manager", {
     version: "v1.15.3",
   },
   image: {
-    repository: randomString.result.apply(result => "public.ecr.aws/eks-anywhere-dev/cert-manager/cert-manager-controller"),
+    repository,
     tag: "v1.15.3-eks-a-v0.21.3-dev-build.0"
   },
   cainjector: {

--- a/examples/simple-cert-manager-ts/package.json
+++ b/examples/simple-cert-manager-ts/package.json
@@ -6,6 +6,8 @@
     "dependencies": {
         "@pulumi/kubernetes": "4.19.0",
         "@pulumi/pulumi": "3.144.1",
-        "@pulumi/kubernetes-cert-manager": "latest"
+        "@pulumi/kubernetes-cert-manager": "latest",
+        "@pulumi/random": "^4.16.8",
+        "google-protobuf": "3.21.4"
     }
 }

--- a/provider/pkg/provider/chart.go
+++ b/provider/pkg/provider/chart.go
@@ -135,16 +135,16 @@ type CertManagerGlobalLeaderElection struct {
 
 type CertManagerImage struct {
 	// You can manage a registry with `registry: quay.io`.
-	Registry *string `pulumi:"registry"`
+	Registry pulumi.StringPtrInput `pulumi:"registry"`
 	// You can manage a registry with `repository: jetstack/cert-manager-controller`.
-	Repository *string `pulumi:"repository"`
+	Repository pulumi.StringPtrInput `pulumi:"repository"`
 	// Override the image tag to deploy by setting this variable.
 	// If no value is set, the chart's appVersion will be used.
-	Tag *string `pulumi:"tag"`
+	Tag pulumi.StringPtrInput `pulumi:"tag"`
 	// Setting a digest will override any tag, e.g.
 	// `digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20`.
-	Digest     *string `pulumi:"digest"`
-	PullPolicy *string `pulumi:"pullPolicy"`
+	Digest     pulumi.StringPtrInput `pulumi:"digest"`
+	PullPolicy pulumi.StringPtrInput `pulumi:"pullPolicy"`
 }
 
 type CertManagerServiceAccount struct {


### PR DESCRIPTION
This adds in a test for #133, with image arguments. It also sets the chart version to match the image version. 