### PR TITLE
Fix sign-goreleaser-exe race on shared Azure CLI state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,9 @@ sign-goreleaser-exe-%: bin/jsign-7.4.jar
 		else \
 			file=dist/build-provider-sign-windows_windows_${GORELEASER_ARCH}/pulumi-resource-kubernetes-cert-manager.exe; \
 			mv $${file} $${file}.unsigned; \
+			AZURE_CONFIG_DIR=$$(mktemp -d); \
+			export AZURE_CONFIG_DIR; \
+			trap 'rm -rf "$${AZURE_CONFIG_DIR}"' EXIT; \
 			az login --service-principal \
 				--username "${AZURE_SIGNING_CLIENT_ID}" \
 				--password "${AZURE_SIGNING_CLIENT_SECRET}" \
@@ -178,7 +181,6 @@ sign-goreleaser-exe-%: bin/jsign-7.4.jar
 				--alias "${AZURE_SIGNING_ACCOUNT_NAME}/${AZURE_SIGNING_CERT_PROFILE_NAME}" \
 				$${file}.unsigned; \
 			mv $${file}.unsigned $${file}; \
-			az logout; \
 		fi; \
 	fi
 


### PR DESCRIPTION
## Summary

- Two concurrent `make sign-goreleaser-exe-{amd64,arm64}` hooks (run as GoReleaser post-hooks for the windows build, parallelism 3) share the default `~/.azure` config dir. The first hook to finish `jsign` runs `az logout`, clearing `accounts.json`; the other hook's subsequent `az logout` then exits non-zero with `ERROR: There are no active accounts.` and kills the recipe under `set -e`.
- Fix: isolate each hook's Azure CLI state via `AZURE_CONFIG_DIR=$(mktemp -d)`, and drop the explicit `az logout` - a `trap 'rm -rf ...' EXIT` cleans up the temp dir regardless of success or failure.
- Fixes #963 (run [24352393675](https://github.com/pulumi/pulumi-kubernetes-cert-manager/actions/runs/24352393675)).

## Evidence

Log from the failed run:

```
16:35:30.7 running hook make sign-goreleaser-exe-amd64
16:35:31.0 running hook make sign-goreleaser-exe-arm64
Adding Authenticode signature to .../kubernetes-cert-manager.exe.unsigned
ERROR: There are no active accounts.
make: *** [Makefile:156: sign-goreleaser-exe-amd64] Error 1
```

I reproduced the exact symptom (`Adding Authenticode signature` followed by `ERROR: There are no active accounts.`) locally with a simulation that models the shared-dir race, and confirmed the isolated-dir fix eliminates it.

## Note on scope

The same recipe lives upstream in `pulumi/ci-mgmt`'s native provider template and is duplicated across pulumi-command, pulumi-kubernetes, pulumi-std, pulumi-docker-build, pulumi-kubernetes-ingress-nginx, pulumi-kubernetes-coredns, pulumi-google-native, pulumi-provider-boilerplate, pulumi-pulumiservice, pulumi-terraform, pulumi-hyperv, and several TF-bridged providers (via `scripts/crossbuild.mk`). They're racing too - just winning on shorter sign windows. This PR unblocks cert-manager; the durable fix belongs in ci-mgmt and will be tracked separately.

## Test plan

- [x] CI's `publish` job completes successfully and produces a Windows binary with a valid Trusted Signing certificate chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)